### PR TITLE
`getParent()`: Handle nodes not in `document.body`

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -53,7 +53,7 @@
   data-greeter-expected="bonjour mon ami"></p>
 
 <script src="../bower_components/qunit/qunit/qunit.js"></script>
-<script src="../bower_components/matches-selector/matches-selector.js"></script>
+<script src="../bower_components/desandro-matches-selector/matches-selector.js"></script>
 <script src="../utils.js"></script>
 
 <script src="unit/make-array.js"></script>

--- a/test/unit/get-parent.js
+++ b/test/unit/get-parent.js
@@ -14,4 +14,17 @@ QUnit.test( 'getParent', function( assert ) {
   parent = getParent( itemA1, '#qunit' );
   assert.ok( parent === undefined, 'parent not tree is undefined' );
 
+  var treeNotInDocument = document.createElement('div');
+  treeNotInDocument.innerHTML =
+    '<div class="a">' +
+      '<div class="a1">' +
+    '</div>';
+
+  parent = getParent( treeNotInDocument.querySelector('.a1'), '.not-found' );
+
+  assert.ok(
+    parent === undefined,
+    'Parent should be `undefined` even when the given tree is not in the document'
+  );
+
 });

--- a/utils.js
+++ b/utils.js
@@ -85,7 +85,7 @@ utils.removeFrom = function( ary, obj ) {
 // ----- getParent ----- //
 
 utils.getParent = function( elem, selector ) {
-  while ( elem != document.body ) {
+  while ( elem.parentNode && elem != document.body ) {
     elem = elem.parentNode;
     if ( matchesSelector( elem, selector ) ) {
       return elem;


### PR DESCRIPTION
When the reference node passed to `getParent()` is not in the body and the search is unsuccessful, `undefined` should still be returned.